### PR TITLE
Simplify ComposerEvent UI.

### DIFF
--- a/src/MusicTimeline/Builders/ComposerEraViewModelBuilder.cs
+++ b/src/MusicTimeline/Builders/ComposerEraViewModelBuilder.cs
@@ -39,11 +39,11 @@ namespace NathanHarrenstein.MusicTimeline.Builders
                 }
                 else if (era.Name == "20th Century")
                 {
-                    background = new SolidColorBrush(Color.FromRgb(205, 173, 74));             // #FFCDAD4A
+                    background = new SolidColorBrush(Color.FromRgb(160, 118, 88));             // #FFA962E0
                 }
                 else if (era.Name == "21st Century")
                 {
-                    background = new SolidColorBrush(Color.FromRgb(219, 109, 138));            // #FFDB6D8A
+                    background = new SolidColorBrush(Color.FromRgb(74, 142, 165));
                 }
 
                 var musicEra = new ComposerEraViewModel(era.Name, ExtendedDateTimeInterval.Parse(era.Dates), background, Brushes.White);

--- a/src/MusicTimeline/Views/TimelinePage.xaml
+++ b/src/MusicTimeline/Views/TimelinePage.xaml
@@ -26,6 +26,12 @@
                 <Separator />
                 <MenuItem Command="{Binding CloseCommand, ElementName=page}" Header="Close" />
             </MenuItem>
+            <MenuItem Header="View">
+                <MenuItem Command="{Binding FullScreenCommand, ElementName=page}" Header="Full Screen" />
+            </MenuItem>
+            <MenuItem Header="Tools">
+                <MenuItem Command="{Binding RebuildThumbnailCacheCommand, ElementName=page}" Header="Rebuild Thumbnail Cache" />
+            </MenuItem>
             <MenuItem Header="Go">
                 <MenuItem Command="{Binding GoToCommand,
                                             ElementName=page}"
@@ -56,21 +62,18 @@
                           CommandParameter="21st Century"
                           Header="21st Century" />
             </MenuItem>
-            <MenuItem Header="View">
-                <MenuItem Command="{Binding FullScreenCommand, ElementName=page}" Header="Full Screen" />
-            </MenuItem>
-            <MenuItem Header="Tools">
-                <MenuItem Command="{Binding RebuildThumbnailCacheCommand, ElementName=page}" Header="Rebuild Thumbnail Cache" />
-            </MenuItem>
         </Menu>
         <t:Timeline Name="timeline"
                     BackgroundImage="{StaticResource BackgroundImage}"
-                    LineStroke="#FF333333"
+                    LineStroke="#FF333333" 
+                    EventHeight="34"
+                    EventSpacing="1"
                     TimeForeground="White">
             <t:Timeline.EraTemplates>
                 <DataTemplate DataType="{x:Type vm:ComposerEraViewModel}">
                     <Grid Background="{Binding Background}" SnapsToDevicePixels="True">
                         <TextBlock Margin="15,0,0,0"
+                                   FontSize="17.333"
                                    VerticalAlignment="Center"
                                    Foreground="{Binding Foreground}"
                                    Text="{Binding Label}" />
@@ -79,7 +82,7 @@
             </t:Timeline.EraTemplates>
             <t:Timeline.EventTemplates>
                 <DataTemplate DataType="{x:Type vm:ComposerEventViewModel}">
-                    <Border Height="60"
+                    <Border Height="34"
                             Background="{Binding Background}"
                             CornerRadius="5"
                             Cursor="Hand">
@@ -89,7 +92,7 @@
                                 Foreground="White">
                             <Button.Template>
                                 <ControlTemplate TargetType="{x:Type Button}">
-                                    <Border Background="Transparent" Padding="7,5,0,5">
+                                    <Border Background="Transparent" Padding="7,0,0,0">
                                         <Grid>
                                             <ContentPresenter />
                                         </Grid>
@@ -99,46 +102,36 @@
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="9" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
-                                <Image SnapsToDevicePixels="True"
-                                       Source="{Binding Composer,
-                                                        Converter={StaticResource ComposerToThumbnailConverter},
-                                                        IsAsync=True}" />
-                                <StackPanel Grid.Column="1" Margin="10,0,0,0">
-                                    <StackPanel Margin="0,1,0,2" Orientation="Horizontal">
-                                        <TextBlock FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Text="{Binding Label}" />
-                                        <ItemsControl ItemsSource="{Binding Composer.Nationalities}">
-                                            <ItemsControl.ItemsPanel>
-                                                <ItemsPanelTemplate>
-                                                    <StackPanel Orientation="Horizontal" />
-                                                </ItemsPanelTemplate>
-                                            </ItemsControl.ItemsPanel>
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate DataType="{x:Type db:Nationality}">
-                                                    <Image Width="16"
-                                                           Height="16"
-                                                           Margin="5,0,0,0"
-                                                           SnapsToDevicePixels="True"
-                                                           Source="{Binding Name,
-                                                                            Converter={StaticResource NationalityToFlagConverter},
-                                                                            IsAsync=True}"
-                                                           UseLayoutRounding="True" />
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                    </StackPanel>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock FontSize="12" Text="Born: " />
-                                        <TextBlock FontSize="12" Text="{Binding Born}" />
-                                    </StackPanel>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock FontSize="12" Text="Died: " />
-                                        <TextBlock FontSize="12" Text="{Binding Died}" />
-                                    </StackPanel>
-                                </StackPanel>
+                                <Image SnapsToDevicePixels="True" Source="{Binding Composer, Converter={StaticResource ComposerToThumbnailConverter}, IsAsync=True}" />
+                                <TextBlock Grid.Column="2"
+                                           FontSize="17.333"
+                                           Margin="0,-1,0,0"
+                                           VerticalAlignment="Center"
+                                           Text="{Binding Label}" />
+                                <ItemsControl Grid.Column="3" Margin="5,0,0,0" VerticalAlignment="Center" ItemsSource="{Binding Composer.Nationalities}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="{x:Type db:Nationality}">
+                                            <Image Width="16"
+                                                   Height="16"
+                                                   Margin="5,0,0,0"
+                                                   SnapsToDevicePixels="True"
+                                                   Source="{Binding Name,
+                                                                    Converter={StaticResource NationalityToFlagConverter},
+                                                                    IsAsync=True}"
+                                                   UseLayoutRounding="True" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
                             </Grid>
                         </Button>
                     </Border>

--- a/src/MusicTimeline/Views/TimelinePage.xaml.cs
+++ b/src/MusicTimeline/Views/TimelinePage.xaml.cs
@@ -131,13 +131,12 @@ namespace NathanHarrenstein.MusicTimeline.Views
             RebuildThumbnailCacheCommand = GetRebuildThumbnailCacheCommand();
             FullScreenCommand = GetFullScreenCommand();
 
-            timeline.Dates = new ExtendedDateTimeInterval(new ExtendedDateTime(1000, 1, 1), ExtendedDateTime.Now);
+            timeline.Dates = new ExtendedDateTimeInterval(new ExtendedDateTime(476, 1, 1), ExtendedDateTime.Now);
             timeline.Eras = composerEraViewModels;
             timeline.Ruler = new TimeRuler();
             timeline.Ruler.TimeRulerUnit = TimeRulerUnit.Day;
             timeline.Ruler.TimeUnitWidth = 0.04109589041;
             timeline.Resolution = TimeResolution.Decade;
-            timeline.EventHeight = 60;
             timeline.Events = ComposerEventViewModelBuilder.Build(composers, composerEraViewModels, timeline);
             timeline.Loaded += Timeline_Loaded;
         }

--- a/src/Timeline/EraPanel.cs
+++ b/src/Timeline/EraPanel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.EDTF;
 using System.Linq;
 using System.Windows;
@@ -24,6 +25,11 @@ namespace NathanHarrenstein.Timeline
         public EraPanel()
         {
             ClipToBounds = true;
+
+            if (DesignerProperties.GetIsInDesignMode(this))
+            {
+                _hasViewChanged = false;
+            }
         }
 
         public ExtendedDateTimeInterval Dates
@@ -100,6 +106,11 @@ namespace NathanHarrenstein.Timeline
 
         public Vector CoercePan(Vector delta)
         {
+            if (Ruler == null)
+            {
+                return delta;
+            }
+
             var extentWidth = Ruler.ToPixels(Dates);
 
             if (HorizontalOffset + delta.X < 0)                                                   // Panning too far left. Set horizontal pan distance to the amount of space remaining before the left edge.
@@ -139,9 +150,9 @@ namespace NathanHarrenstein.Timeline
                 var dates = Eras[visibleCacheIndex].Dates;
 
                 _cache[visibleCacheIndex].Arrange(new Rect(
-                    Ruler.ToPixels(Dates.Earliest() + Ruler.ToTimeSpan(HorizontalOffset), dates.Earliest()), 
-                    0, 
-                    Ruler.ToPixels(dates), 
+                    Ruler.ToPixels(Dates.Earliest() + Ruler.ToTimeSpan(HorizontalOffset), dates.Earliest()),
+                    0,
+                    Ruler.ToPixels(dates),
                     finalSize.Height));
             }
 
@@ -149,7 +160,7 @@ namespace NathanHarrenstein.Timeline
         }
 
         protected override Size MeasureOverride(Size availableSize)
-        {          
+        {
             if (_hasViewChanged)
             {
                 if (_cache == null)

--- a/src/Timeline/EventPanel.cs
+++ b/src/Timeline/EventPanel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.EDTF;
 using System.Linq;
 using System.Windows;
@@ -28,7 +29,15 @@ namespace NathanHarrenstein.Timeline
         public EventPanel()
         {
             ClipToBounds = true;
-            SizeChanged += EventPanel_SizeChanged;
+
+            if (DesignerProperties.GetIsInDesignMode(this))
+            {
+                _hasViewChanged = false;
+            }
+            else
+            {
+                SizeChanged += EventPanel_SizeChanged;
+            }
         }
 
         public ExtendedDateTimeInterval Dates
@@ -156,6 +165,11 @@ namespace NathanHarrenstein.Timeline
 
         public Vector CoercePan(Vector delta)
         {
+            if (Ruler == null)
+            {
+                return delta;
+            }
+
             var extentWidth = Ruler.ToPixels(Dates);
             var extentHeight = Events.Count() * (EventSpacing + EventHeight);
 

--- a/src/Timeline/GuidelinePanel.cs
+++ b/src/Timeline/GuidelinePanel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.EDTF;
 using System.Windows;
 using System.Windows.Controls;
@@ -17,18 +18,19 @@ namespace NathanHarrenstein.Timeline
         public static readonly DependencyProperty ResolutionProperty = DependencyProperty.Register("Resolution", typeof(TimeResolution), typeof(GuidelinePanel));
         public static readonly DependencyProperty RulerProperty = DependencyProperty.Register("Ruler", typeof(TimeRuler), typeof(GuidelinePanel));
         private bool _hasViewChanged = true;
-        private Dictionary<int, double> _lineOffsets;
         private double _horizontalOffset;
+        private Dictionary<int, double> _lineOffsets;
 
         public GuidelinePanel()
         {
-            SizeChanged += GuidelinePanel_SizeChanged;
-        }
-
-        private void GuidelinePanel_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            _hasViewChanged = true;
-            InvalidateMeasure();
+            if (DesignerProperties.GetIsInDesignMode(this))
+            {
+                _hasViewChanged = false;
+            }
+            else
+            {
+                SizeChanged += GuidelinePanel_SizeChanged;
+            }
         }
 
         public ExtendedDateTimeInterval Dates
@@ -308,6 +310,12 @@ namespace NathanHarrenstein.Timeline
             }
 
             return availableSize;
+        }
+
+        private void GuidelinePanel_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            _hasViewChanged = true;
+            InvalidateMeasure();
         }
     }
 }

--- a/src/Timeline/Themes/Generic.xaml
+++ b/src/Timeline/Themes/Generic.xaml
@@ -18,7 +18,7 @@
                             </Grid.RowDefinitions>
                             <l:BackgroundPanel Grid.RowSpan="3" BackgroundImage="{TemplateBinding BackgroundImage}" />
                             <l:EraPanel Grid.Row="0"
-                                        Height="26"
+                                        Height="29"
                                         Dates="{TemplateBinding Dates}"
                                         EraTemplates="{TemplateBinding EraTemplates}"
                                         Eras="{TemplateBinding Eras}"

--- a/src/Timeline/TimePanel.cs
+++ b/src/Timeline/TimePanel.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.EDTF;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using System.Windows.Shapes;
 
 namespace NathanHarrenstein.Timeline
 {
@@ -22,6 +22,14 @@ namespace NathanHarrenstein.Timeline
         private bool _hasViewChanged = true;
         private double _horizontalOffset;
         private Dictionary<int, double> _labelOffsets;
+
+        public TimePanel()
+        {
+            if (DesignerProperties.GetIsInDesignMode(this))
+            {
+                _hasViewChanged = false;
+            }
+        }
 
         public ExtendedDateTimeInterval Dates
         {
@@ -177,9 +185,9 @@ namespace NathanHarrenstein.Timeline
         {
             if (_hasViewChanged)
             {
-                // In determining the labels to display, it must be kept in mind that the spacings between 
-                // the labels might be variable depending on the current time unit. For instance, if the 
-                // timeline is measured in months, then the labels will not be equally spaced apart because 
+                // In determining the labels to display, it must be kept in mind that the spacings between
+                // the labels might be variable depending on the current time unit. For instance, if the
+                // timeline is measured in months, then the labels will not be equally spaced apart because
                 // a month is anywhere from 28 to 31 days. The solution is to produce labels one at a time
                 // while the total accumulated width is less than the viewport width.
                 //


### PR DESCRIPTION
Remove Born and Died from ComposerEvent because it is data which does not benefit by being on the timeline, adds considerable visual clutter, and limits the number of events which can be rendered on the screen. The menu was also reordered to a more standard ordering. The timeline dates were adjusted to the very beginning of the Medieval era so the label would be visible.
