### PR TITLE
Use 40px EventHeight.

### DIFF
--- a/src/MusicTimeline/Views/TimelinePage.xaml
+++ b/src/MusicTimeline/Views/TimelinePage.xaml
@@ -66,7 +66,7 @@
         <t:Timeline Name="timeline"
                     BackgroundImage="{StaticResource BackgroundImage}"
                     LineStroke="#FF333333" 
-                    EventHeight="34"
+                    EventHeight="40"
                     EventSpacing="1"
                     TimeForeground="White">
             <t:Timeline.EraTemplates>
@@ -82,7 +82,7 @@
             </t:Timeline.EraTemplates>
             <t:Timeline.EventTemplates>
                 <DataTemplate DataType="{x:Type vm:ComposerEventViewModel}">
-                    <Border Height="34"
+                    <Border Height="40"
                             Background="{Binding Background}"
                             CornerRadius="5"
                             Cursor="Hand">


### PR DESCRIPTION
Use a slightly taller EventHeight to get a better balance between the image size and the compactness of the event.
