### PR TITLE
Optimize Composer query

### DIFF
--- a/src/ClassicalMusicDb/ClassicalMusicContext.cs
+++ b/src/ClassicalMusicDb/ClassicalMusicContext.cs
@@ -17,6 +17,7 @@ namespace NathanHarrenstein.ClassicalMusicDb
         public virtual DbSet<Catalog> Catalogs { get; set; }
         public virtual DbSet<CatalogNumber> CatalogNumbers { get; set; }
         public virtual DbSet<Composer> Composers { get; set; }
+        public virtual DbSet<ComposerDetails> ComposerDetails { get; set; }
         public virtual DbSet<ComposerImage> ComposerImages { get; set; }
         public virtual DbSet<Composition> Compositions { get; set; }
         public virtual DbSet<CompositionCollection> CompositionCollections { get; set; }
@@ -115,12 +116,12 @@ namespace NathanHarrenstein.ClassicalMusicDb
                 .Map(m => m.ToTable("CompositionCollectionRecording").MapLeftKey("CompositionCollectionId").MapRightKey("RecordingId"));
 
             modelBuilder.Entity<Location>()
-                .HasMany(e => e.BirthLocationComposers)
+                .HasMany(e => e.BirthLocationComposerDetailsCollection)
                 .WithOptional(e => e.BirthLocation)
                 .HasForeignKey(e => e.BirthLocationId);
 
             modelBuilder.Entity<Location>()
-                .HasMany(e => e.DeathLocationComposers)
+                .HasMany(e => e.DeathLocationComposerDetailsCollection)
                 .WithOptional(e => e.DeathLocation)
                 .HasForeignKey(e => e.DeathLocationId);
 
@@ -138,6 +139,10 @@ namespace NathanHarrenstein.ClassicalMusicDb
                 .HasMany(e => e.Recordings)
                 .WithMany(e => e.Performers)
                 .Map(m => m.ToTable("RecordingPerformer").MapLeftKey("PerformerId").MapRightKey("RecordingId"));
+
+            modelBuilder.Entity<Composer>()
+                .HasRequired(e => e.Details)
+                .WithRequiredDependent(e => e.Composer);
         }
     }
 }

--- a/src/ClassicalMusicDb/ClassicalMusicDb.csproj
+++ b/src/ClassicalMusicDb/ClassicalMusicDb.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Performer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Recording.cs" />
+    <Compile Include="ComposerDetails.cs" />
     <Compile Include="Sample.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ClassicalMusicDb/Composer.cs
+++ b/src/ClassicalMusicDb/Composer.cs
@@ -33,20 +33,10 @@ namespace NathanHarrenstein.ClassicalMusicDb
         [Required]
         public string Dates { get; set; }
 
-        public int? BirthLocationId { get; set; }
-
-        public int? DeathLocationId { get; set; }
-
-        public string Biography { get; set; }
-
-        public bool IsPopular { get; set; }
+        public virtual ComposerDetails Details { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Catalog> Catalogs { get; set; }
-
-        public virtual Location BirthLocation { get; set; }
-
-        public virtual Location DeathLocation { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<ComposerImage> ComposerImages { get; set; }

--- a/src/ClassicalMusicDb/ComposerDetails.cs
+++ b/src/ClassicalMusicDb/ComposerDetails.cs
@@ -1,0 +1,30 @@
+﻿namespace NathanHarrenstein.ClassicalMusicDb
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.ComponentModel.DataAnnotations;
+    using System.ComponentModel.DataAnnotations.Schema;
+    using System.Data.Entity.Spatial;
+
+    [Table("Composer")]
+    public partial class ComposerDetails
+    {
+        [Key]
+        public int ComposerId { get; set; }
+
+        public int? BirthLocationId { get; set; }
+
+        public int? DeathLocationId { get; set; }
+
+        public string Biography { get; set; }
+
+        public bool IsPopular { get; set; }
+
+        public virtual Location BirthLocation { get; set; }
+
+        public virtual Location DeathLocation { get; set; }
+
+        public virtual Composer Composer { get; set; }
+    }
+}

--- a/src/ClassicalMusicDb/Location.cs
+++ b/src/ClassicalMusicDb/Location.cs
@@ -13,8 +13,8 @@ namespace NathanHarrenstein.ClassicalMusicDb
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
         public Location()
         {
-            BirthLocationComposers = new ObservableCollection<Composer>();
-            DeathLocationComposers = new ObservableCollection<Composer>();
+            BirthLocationComposerDetailsCollection = new ObservableCollection<ComposerDetails>();
+            DeathLocationComposerDetailsCollection = new ObservableCollection<ComposerDetails>();
             Recordings = new ObservableCollection<Recording>();
         }
 
@@ -24,10 +24,10 @@ namespace NathanHarrenstein.ClassicalMusicDb
         public string Name { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual ICollection<Composer> BirthLocationComposers { get; set; }
+        public virtual ICollection<ComposerDetails> BirthLocationComposerDetailsCollection { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual ICollection<Composer> DeathLocationComposers { get; set; }
+        public virtual ICollection<ComposerDetails> DeathLocationComposerDetailsCollection { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Recording> Recordings { get; set; }

--- a/src/MusicLibraryDb/MusicLibraryDb.csproj
+++ b/src/MusicLibraryDb/MusicLibraryDb.csproj
@@ -72,9 +72,6 @@
     <Compile Include="Recording.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5">
       <Visible>False</Visible>
       <ProductName>Microsoft .NET Framework 4.5 %28x86 and x64%29</ProductName>
@@ -85,6 +82,9 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/MusicLibraryDb/packages.config
+++ b/src/MusicLibraryDb/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
 </packages>

--- a/src/MusicTimeline/Builders/ComposerEventViewModelBuilder.cs
+++ b/src/MusicTimeline/Builders/ComposerEventViewModelBuilder.cs
@@ -65,7 +65,7 @@ namespace NathanHarrenstein.MusicTimeline.Builders
                     background,
                     Brushes.White,
                     composerEras,
-                    GetCommand(composer, timeline));
+                    GetCommand(composer.Name, timeline));
 
                 eventList.Add(composerEvent);
             }
@@ -73,11 +73,11 @@ namespace NathanHarrenstein.MusicTimeline.Builders
             return eventList.OrderBy(e => e.Dates.Earliest()).ToList();
         }
 
-        private static DelegateCommand GetCommand(Composer composer, Timeline.Timeline timeline)
+        private static DelegateCommand GetCommand(string composerName, Timeline.Timeline timeline)
         {
             Action<object> command = o =>
             {
-                Application.Current.Properties["SelectedComposer"] = composer.Name;
+                Application.Current.Properties["SelectedComposer"] = composerName;
                 Application.Current.Properties["HorizontalOffset"] = timeline.HorizontalOffset;
                 Application.Current.Properties["VerticalOffset"] = timeline.VerticalOffset;
 

--- a/src/MusicTimeline/Views/ComposerPage.xaml.cs
+++ b/src/MusicTimeline/Views/ComposerPage.xaml.cs
@@ -148,9 +148,9 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
         private static string GetBorn(Composer composer)
         {
-            if (composer.BirthLocation != null)
+            if (composer.Details.BirthLocation != null)
             {
-                return $"{ExtendedDateTimeInterval.Parse(composer.Dates).Start}; {composer.BirthLocation.Name}";
+                return $"{ExtendedDateTimeInterval.Parse(composer.Dates).Start}; {composer.Details.BirthLocation.Name}";
             }
 
             return ExtendedDateTimeInterval.Parse(composer.Dates).Start.ToString();
@@ -158,9 +158,9 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
         private static string GetDied(Composer composer)
         {
-            if (composer.DeathLocation != null)
+            if (composer.Details.DeathLocation != null)
             {
-                return $"{ExtendedDateTimeInterval.Parse(composer.Dates).End}; {composer.DeathLocation.Name}";
+                return $"{ExtendedDateTimeInterval.Parse(composer.Dates).End}; {composer.Details.DeathLocation.Name}";
             }
 
             return ExtendedDateTimeInterval.Parse(composer.Dates).End.ToString();
@@ -175,7 +175,7 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
         private void BuildBiographySection(Composer composer)
         {
-            if (composer.Biography == null)
+            if (composer.Details.Biography == null)
             {
                 return;
             }
@@ -184,7 +184,7 @@ namespace NathanHarrenstein.MusicTimeline.Views
             parserContext.XmlnsDictionary.Add("", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
             parserContext.XmlSpace = "preserve";
 
-            var section = (Section)XamlReader.Load(new MemoryStream(Encoding.UTF8.GetBytes(composer.Biography)), parserContext);
+            var section = (Section)XamlReader.Load(new MemoryStream(Encoding.UTF8.GetBytes(composer.Details.Biography)), parserContext);
 
             if (section == null)
             {

--- a/src/MusicTimeline/Views/InputPage.xaml.cs
+++ b/src/MusicTimeline/Views/InputPage.xaml.cs
@@ -240,12 +240,12 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
                 ComposerNameTextBox.SetBinding(TextBox.TextProperty, BindingBuilder.Build(composer, "Name"));
                 ComposerDatesTextBox.SetBinding(TextBox.TextProperty, BindingBuilder.Build(composer, "Dates"));
-                ComposerBirthLocationAutoCompleteBox.Text = composer.BirthLocation?.Name;
-                ComposerDeathLocationAutoCompleteBox.Text = composer.DeathLocation?.Name;
+                ComposerBirthLocationAutoCompleteBox.Text = composer.Details.BirthLocation?.Name;
+                ComposerDeathLocationAutoCompleteBox.Text = composer.Details.DeathLocation?.Name;
                 ComposerInfluenceListBox.SetBinding(ItemsControl.ItemsSourceProperty, BindingBuilder.Build(composer.Influences, null, "Name"));
                 ComposerImageListBox.SetBinding(ItemsControl.ItemsSourceProperty, BindingBuilder.Build(composer.ComposerImages, null));
                 ComposerLinkListBox.SetBinding(ItemsControl.ItemsSourceProperty, BindingBuilder.Build(composer.Links, null));
-                ComposerBiographyTextBox.SetBinding(TextBox.TextProperty, BindingBuilder.Build(composer, "Biography"));
+                ComposerBiographyTextBox.SetBinding(TextBox.TextProperty, BindingBuilder.Build(composer.Details, "Biography"));
                 CompositionCollectionListBox.SetBinding(ItemsControl.ItemsSourceProperty, BindingBuilder.Build(composer.CompositionCollections, null, "Name"));
                 CompositionListBox.SetBinding(ItemsControl.ItemsSourceProperty, BindingBuilder.Build(composer.Compositions, null, "Name"));
 
@@ -482,14 +482,14 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
             if (birthLocationQuery == null)                                                                                                                                                                                // New location does not exist in database.
             {
-                if (composer.BirthLocation != null && composer.BirthLocation.BirthLocationComposers.Count + composer.BirthLocation.DeathLocationComposers.Count + composer.BirthLocation.Recordings.Count == 1)            // Delete old location if only reference is gone.
+                if (composer.Details.BirthLocation != null && composer.Details.BirthLocation.BirthLocationComposerDetailsCollection.Count + composer.Details.BirthLocation.DeathLocationComposerDetailsCollection.Count + composer.Details.BirthLocation.Recordings.Count == 1)            // Delete old location if only reference is gone.
                 {
-                    _classicalMusicContext.Locations.Remove(composer.BirthLocation);
+                    _classicalMusicContext.Locations.Remove(composer.Details.BirthLocation);
                 }
 
                 if (string.IsNullOrEmpty(ComposerBirthLocationAutoCompleteBox.Text))
                 {
-                    composer.BirthLocation = null;
+                    composer.Details.BirthLocation = null;
                 }
                 else
                 {
@@ -497,17 +497,17 @@ namespace NathanHarrenstein.MusicTimeline.Views
                     location.Name = ComposerBirthLocationAutoCompleteBox.Text;
 
                     _classicalMusicContext.Locations.Add(location);
-                    composer.BirthLocation = location;
+                    composer.Details.BirthLocation = location;
                 }
             }
             else                                                                                                                                                                                                           // New location does exist.
             {
-                if (composer.BirthLocation != null && birthLocationQuery.Name != composer.BirthLocation.Name && composer.BirthLocation.BirthLocationComposers.Count + composer.BirthLocation.DeathLocationComposers.Count + composer.BirthLocation.Recordings.Count == 1) // Delete old location if only reference is gone.
+                if (composer.Details.BirthLocation != null && birthLocationQuery.Name != composer.Details.BirthLocation.Name && composer.Details.BirthLocation.BirthLocationComposerDetailsCollection.Count + composer.Details.BirthLocation.DeathLocationComposerDetailsCollection.Count + composer.Details.BirthLocation.Recordings.Count == 1) // Delete old location if only reference is gone.
                 {
-                    _classicalMusicContext.Locations.Remove(composer.BirthLocation);
+                    _classicalMusicContext.Locations.Remove(composer.Details.BirthLocation);
                 }
 
-                composer.BirthLocation = birthLocationQuery;
+                composer.Details.BirthLocation = birthLocationQuery;
             }
         }
 
@@ -519,14 +519,14 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
             if (deathLocationQuery == null)                                                                                                                                                                                // New location does not exist in database.
             {
-                if (composer.DeathLocation != null && composer.DeathLocation.BirthLocationComposers.Count + composer.DeathLocation.DeathLocationComposers.Count + composer.DeathLocation.Recordings.Count == 1)            // Delete old location if only reference is gone.
+                if (composer.Details.DeathLocation != null && composer.Details.DeathLocation.BirthLocationComposerDetailsCollection.Count + composer.Details.DeathLocation.DeathLocationComposerDetailsCollection.Count + composer.Details.DeathLocation.Recordings.Count == 1)            // Delete old location if only reference is gone.
                 {
-                    _classicalMusicContext.Locations.Remove(composer.DeathLocation);
+                    _classicalMusicContext.Locations.Remove(composer.Details.DeathLocation);
                 }
 
                 if (string.IsNullOrEmpty(ComposerDeathLocationAutoCompleteBox.Text))
                 {
-                    composer.DeathLocation = null;
+                    composer.Details.DeathLocation = null;
                 }
                 else
                 {
@@ -534,17 +534,17 @@ namespace NathanHarrenstein.MusicTimeline.Views
                     location.Name = ComposerDeathLocationAutoCompleteBox.Text;
 
                     _classicalMusicContext.Locations.Add(location);
-                    composer.DeathLocation = location;
+                    composer.Details.DeathLocation = location;
                 }
             }
             else                                                                                                                                                                                                           // New location does exist.
             {
-                if (composer.DeathLocation != null && deathLocationQuery.Name != composer.DeathLocation.Name && composer.DeathLocation.BirthLocationComposers.Count + composer.DeathLocation.DeathLocationComposers.Count + composer.DeathLocation.Recordings.Count == 1) // Delete old location if only reference is gone.
+                if (composer.Details.DeathLocation != null && deathLocationQuery.Name != composer.Details.DeathLocation.Name && composer.Details.DeathLocation.BirthLocationComposerDetailsCollection.Count + composer.Details.DeathLocation.DeathLocationComposerDetailsCollection.Count + composer.Details.DeathLocation.Recordings.Count == 1) // Delete old location if only reference is gone.
                 {
-                    _classicalMusicContext.Locations.Remove(composer.DeathLocation);
+                    _classicalMusicContext.Locations.Remove(composer.Details.DeathLocation);
                 }
 
-                composer.DeathLocation = deathLocationQuery;
+                composer.Details.DeathLocation = deathLocationQuery;
             }
         }
 
@@ -666,7 +666,7 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
                     if (url.Contains("wikipedia"))
                     {
-                        _selectedComposers[0].Biography = BiographyUtility.CleanXaml(HtmlToXamlConverter.ConvertHtmlToXaml(WikipediaScraper.ScrapeArticle(url), false));
+                        _selectedComposers[0].Details.Biography = BiographyUtility.CleanXaml(HtmlToXamlConverter.ConvertHtmlToXaml(WikipediaScraper.ScrapeArticle(url), false));
                         ComposerBiographyTextBox.GetBindingExpression(TextBox.TextProperty).UpdateTarget();
                     }
 
@@ -1307,7 +1307,7 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
                 location.Recordings.Remove(_selectedRecording);
 
-                if (location.Recordings.Count == 0 && location.BirthLocationComposers.Count == 0 && location.DeathLocationComposers.Count == 0)
+                if (location.Recordings.Count == 0 && location.BirthLocationComposerDetailsCollection.Count == 0 && location.DeathLocationComposerDetailsCollection.Count == 0)
                 {
                     _classicalMusicContext.Locations.Local.Remove(location);
                 }


### PR DESCRIPTION
To improve startup time of the TimelinePage, we employ the "table splitting" feature of Entity Framework. All of the Composer fields which are unused during the loading of TimelinePage are delegated to a ComposerDetails class. This makes a big difference because the biography field in particular is very large and does not lazily load.

The other option I considered was to split the database table and have two separate entities, but I felt that the database structure should not be dependent on how a single application uses the data, otherwise problems might arise if another application uses the database which has a different set of optimization requirements.
