### PR TITLE
Switch from FlacPlayer to Mp3Player

### DIFF
--- a/src/MusicTimeline/Audio/Mp3Player.cs
+++ b/src/MusicTimeline/Audio/Mp3Player.cs
@@ -1,6 +1,5 @@
 ﻿using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Flac;
 using NAudio.Wave;
 using System;
 using System.Collections.Generic;
@@ -12,14 +11,14 @@ using System.Windows.Threading;
 
 namespace NathanHarrenstein.MusicTimeline.Audio
 {
-    public class FlacPlayer : IDisposable, IAudioSessionEventsHandler
+    public class Mp3Player : IDisposable, IAudioSessionEventsHandler
     {
-        private readonly LinkedList<FlacReader> _playlist;
+        private readonly LinkedList<Mp3FileReader> _playlist;
         private AudioSessionControl _audioSessionControl;
         private bool _canPlay;
         private bool _canSkipBack;
         private bool _canSkipForward;
-        private LinkedListNode<FlacReader> _currentPlaylistItem;
+        private LinkedListNode<Mp3FileReader> _currentPlaylistItem;
         private bool _isDisposed;
         private bool _isMuted;
         private MMDevice _playbackDevice;
@@ -27,9 +26,9 @@ namespace NathanHarrenstein.MusicTimeline.Audio
         private DispatcherTimer _playbackTimer;
         private WaveOutEvent _player;
 
-        public FlacPlayer()
+        public Mp3Player()
         {
-            _playlist = new LinkedList<FlacReader>();
+            _playlist = new LinkedList<Mp3FileReader>();
             _playbackTimer = new DispatcherTimer();
             _playbackTimer.Interval = new TimeSpan(1);
             _playbackTimer.Tick += PlaybackTimer_Tick;
@@ -41,7 +40,7 @@ namespace NathanHarrenstein.MusicTimeline.Audio
             _isMuted = _playbackDevice.AudioEndpointVolume.Mute;
         }
 
-        ~FlacPlayer()
+        ~Mp3Player()
         {
             Dispose(false);
         }
@@ -98,7 +97,7 @@ namespace NathanHarrenstein.MusicTimeline.Audio
             }
         }
 
-        public LinkedListNode<FlacReader> CurrentPlaylistItem
+        public LinkedListNode<Mp3FileReader> CurrentPlaylistItem
         {
             get
             {
@@ -155,7 +154,7 @@ namespace NathanHarrenstein.MusicTimeline.Audio
             }
         }
 
-        public LinkedList<FlacReader> Playlist
+        public LinkedList<Mp3FileReader> Playlist
         {
             get
             {
@@ -203,9 +202,9 @@ namespace NathanHarrenstein.MusicTimeline.Audio
             }
         }
 
-        public void AddToPlaylist(FlacReader flacReader)
+        public void AddToPlaylist(Mp3FileReader mp3FileReader)
         {
-            _playlist.AddLast(flacReader);
+            _playlist.AddLast(mp3FileReader);
 
             if (_playlist.Count == 1)
             {
@@ -507,7 +506,7 @@ namespace NathanHarrenstein.MusicTimeline.Audio
             UpdatePlaybackState();
         }
 
-        private void Load(LinkedListNode<FlacReader> playlistItem)
+        private void Load(LinkedListNode<Mp3FileReader> playlistItem)
         {
             if (playlistItem == null)
             {

--- a/src/MusicTimeline/Audio/TrackEventArgs.cs
+++ b/src/MusicTimeline/Audio/TrackEventArgs.cs
@@ -5,14 +5,14 @@ namespace NathanHarrenstein.MusicTimeline.Audio
 {
     public class TrackEventArgs : EventArgs
     {
-        private readonly ISampleProvider _track;
+        private readonly IWaveProvider _track;
 
-        public TrackEventArgs(ISampleProvider track)
+        public TrackEventArgs(IWaveProvider track)
         {
             _track = track;
         }
 
-        public ISampleProvider Track
+        public IWaveProvider Track
         {
             get
             {

--- a/src/MusicTimeline/MusicTimeline.csproj
+++ b/src/MusicTimeline/MusicTimeline.csproj
@@ -81,10 +81,6 @@
       <HintPath>..\packages\NAudio.1.7.3\lib\net35\NAudio.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NAudio.Flac, Version=1.0.5702.29018, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.Flac.1.0.5702.29018\lib\net45\NAudio.Flac.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="presentationframework.aero2" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -112,7 +108,7 @@
     <Compile Include="Audio\CanPlayEventArgs.cs" />
     <Compile Include="Audio\CanSkipBackEventArgs.cs" />
     <Compile Include="Audio\CanSkipForwardEventArgs.cs" />
-    <Compile Include="Audio\FlacPlayer.cs" />
+    <Compile Include="Audio\Mp3Player.cs" />
     <Compile Include="Audio\MuteEventArgs.cs" />
     <Compile Include="Audio\VolumeEventArgs.cs" />
     <Compile Include="Controls\AutoCompleteBox.cs" />

--- a/src/MusicTimeline/Views/ComposerPage.xaml.cs
+++ b/src/MusicTimeline/Views/ComposerPage.xaml.cs
@@ -3,7 +3,6 @@ using NathanHarrenstein.MusicTimeline.Audio;
 using NathanHarrenstein.MusicTimeline.Builders;
 using NathanHarrenstein.MusicTimeline.Comparers;
 using NathanHarrenstein.MusicTimeline.Utilities;
-using NAudio.Flac;
 using NAudio.Wave;
 using System;
 using System.Collections.Generic;
@@ -30,9 +29,9 @@ namespace NathanHarrenstein.MusicTimeline.Views
         private static LogicalComparer _logicalComparer;
         private ClassicalMusicContext _classicalMusicContext;
         private Composer _composer;
-        private FlacPlayer _flacPlayer;
+        private Mp3Player _mp3Player;
         private bool _isDisposed;
-        private Dictionary<ISampleProvider, Sample> _sampleDictionary;
+        private Dictionary<IWaveProvider, Sample> _sampleDictionary;
 
         public ComposerPage()
         {
@@ -40,18 +39,18 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
             _logicalComparer = new LogicalComparer();
             _classicalMusicContext = new ClassicalMusicContext();
-            _sampleDictionary = new Dictionary<ISampleProvider, Sample>();
-            _flacPlayer = new FlacPlayer();
+            _sampleDictionary = new Dictionary<IWaveProvider, Sample>();
+            _mp3Player = new Mp3Player();
 
-            _flacPlayer.CurrentTimeChanged += FlacPlayer_CurrentTimeChanged;
-            _flacPlayer.TotalTimeChanged += FlacPlayer_TotalTimeChanged;
-            _flacPlayer.TrackChanged += FlacPlayer_TrackChanged;
-            _flacPlayer.PlaybackStateChanged += FlacPlayer_PlaybackStateChanged;
-            _flacPlayer.VolumeChanged += FlacPlayer_VolumeChanged;
-            _flacPlayer.IsMutedChanged += FlacPlayer_IsMutedChanged;
-            _flacPlayer.CanPlayChanged += FlacPlayer_CanPlayChanged;
-            _flacPlayer.CanSkipBackChanged += FlacPlayer_CanSkipBackChanged;
-            _flacPlayer.CanSkipForwardChanged += FlacPlayer_CanSkipForwardChanged;
+            _mp3Player.CurrentTimeChanged += Mp3Player_CurrentTimeChanged;
+            _mp3Player.TotalTimeChanged += Mp3Player_TotalTimeChanged;
+            _mp3Player.TrackChanged += Mp3Player_TrackChanged;
+            _mp3Player.PlaybackStateChanged += Mp3Player_PlaybackStateChanged;
+            _mp3Player.VolumeChanged += Mp3Player_VolumeChanged;
+            _mp3Player.IsMutedChanged += Mp3Player_IsMutedChanged;
+            _mp3Player.CanPlayChanged += Mp3Player_CanPlayChanged;
+            _mp3Player.CanSkipBackChanged += Mp3Player_CanSkipBackChanged;
+            _mp3Player.CanSkipForwardChanged += Mp3Player_CanSkipForwardChanged;
 
             Loaded += ComposerPage_Loaded;
         }
@@ -140,7 +139,7 @@ namespace NathanHarrenstein.MusicTimeline.Views
             if (!_isDisposed)
             {
                 _classicalMusicContext.Dispose();
-                _flacPlayer.Dispose();
+                _mp3Player.Dispose();
 
                 _isDisposed = true;
             }
@@ -240,19 +239,19 @@ namespace NathanHarrenstein.MusicTimeline.Views
         {
             _sampleDictionary.Clear();
 
-            _flacPlayer.Dispose();
+            _mp3Player.Dispose();
 
-            _flacPlayer = new FlacPlayer();
+            _mp3Player = new Mp3Player();
 
-            _flacPlayer.CurrentTimeChanged += FlacPlayer_CurrentTimeChanged;
-            _flacPlayer.TotalTimeChanged += FlacPlayer_TotalTimeChanged;
-            _flacPlayer.TrackChanged += FlacPlayer_TrackChanged;
-            _flacPlayer.PlaybackStateChanged += FlacPlayer_PlaybackStateChanged;
-            _flacPlayer.VolumeChanged += FlacPlayer_VolumeChanged;
-            _flacPlayer.IsMutedChanged += FlacPlayer_IsMutedChanged;
-            _flacPlayer.CanPlayChanged += FlacPlayer_CanPlayChanged;
-            _flacPlayer.CanSkipBackChanged += FlacPlayer_CanSkipBackChanged;
-            _flacPlayer.CanSkipForwardChanged += FlacPlayer_CanSkipForwardChanged;
+            _mp3Player.CurrentTimeChanged += Mp3Player_CurrentTimeChanged;
+            _mp3Player.TotalTimeChanged += Mp3Player_TotalTimeChanged;
+            _mp3Player.TrackChanged += Mp3Player_TrackChanged;
+            _mp3Player.PlaybackStateChanged += Mp3Player_PlaybackStateChanged;
+            _mp3Player.VolumeChanged += Mp3Player_VolumeChanged;
+            _mp3Player.IsMutedChanged += Mp3Player_IsMutedChanged;
+            _mp3Player.CanPlayChanged += Mp3Player_CanPlayChanged;
+            _mp3Player.CanSkipBackChanged += Mp3Player_CanSkipBackChanged;
+            _mp3Player.CanSkipForwardChanged += Mp3Player_CanSkipForwardChanged;
 
             NowPlayingTitleTextBlock.Text = null;
             NowPlayingArtistTextBlock.Text = null;
@@ -271,52 +270,52 @@ namespace NathanHarrenstein.MusicTimeline.Views
             await LoadComposerAsync();
         }
 
-        private void FlacPlayer_CanPlayChanged(object sender, CanPlayEventArgs e)
+        private void Mp3Player_CanPlayChanged(object sender, CanPlayEventArgs e)
         {
             PlayPauseToggleButton.IsEnabled = e.CanPlay;
         }
 
-        private void FlacPlayer_CanSkipBackChanged(object sender, CanSkipBackEventArgs e)
+        private void Mp3Player_CanSkipBackChanged(object sender, CanSkipBackEventArgs e)
         {
             SkipBackButton.IsEnabled = e.CanSkipBack;
         }
 
-        private void FlacPlayer_CanSkipForwardChanged(object sender, CanSkipForwardEventArgs e)
+        private void Mp3Player_CanSkipForwardChanged(object sender, CanSkipForwardEventArgs e)
         {
             SkipForwardButton.IsEnabled = e.CanSkipForward;
         }
 
-        private void FlacPlayer_CurrentTimeChanged(object sender, TimeSpanEventArgs e)
+        private void Mp3Player_CurrentTimeChanged(object sender, TimeSpanEventArgs e)
         {
             ProgressSlider.IsEnabled = true;
             ProgressSlider.Value = e.TimeSpan.Ticks;
         }
 
-        private void FlacPlayer_IsMutedChanged(object sender, MuteEventArgs e)
+        private void Mp3Player_IsMutedChanged(object sender, MuteEventArgs e)
         {
             MuteToggleButton.IsEnabled = true;
             MuteToggleButton.IsChecked = e.Mute;
         }
 
-        private void FlacPlayer_PlaybackStateChanged(object sender, PlaybackStateEventArgs e)
+        private void Mp3Player_PlaybackStateChanged(object sender, PlaybackStateEventArgs e)
         {
             PlayPauseToggleButton.IsEnabled = true;
             PlayPauseToggleButton.IsChecked = e.PlaybackState == PlaybackState.Playing ? true : false;
         }
 
-        private void FlacPlayer_TotalTimeChanged(object sender, TimeSpanEventArgs e)
+        private void Mp3Player_TotalTimeChanged(object sender, TimeSpanEventArgs e)
         {
             ProgressSlider.IsEnabled = true;
             ProgressSlider.Maximum = e.TimeSpan.Ticks;
         }
 
-        private void FlacPlayer_TrackChanged(object sender, TrackEventArgs e)
+        private void Mp3Player_TrackChanged(object sender, TrackEventArgs e)
         {
-            NowPlayingTitleTextBlock.Text = _sampleDictionary[_flacPlayer.CurrentPlaylistItem.Value].Title;
-            NowPlayingArtistTextBlock.Text = _sampleDictionary[_flacPlayer.CurrentPlaylistItem.Value].Artists;
+            NowPlayingTitleTextBlock.Text = _sampleDictionary[_mp3Player.CurrentPlaylistItem.Value].Title;
+            NowPlayingArtistTextBlock.Text = _sampleDictionary[_mp3Player.CurrentPlaylistItem.Value].Artists;
         }
 
-        private void FlacPlayer_VolumeChanged(object sender, VolumeEventArgs e)
+        private void Mp3Player_VolumeChanged(object sender, VolumeEventArgs e)
         {
             VolumeSlider.IsEnabled = true;
             VolumeSlider.Value = e.Volume;
@@ -337,34 +336,34 @@ namespace NathanHarrenstein.MusicTimeline.Views
         {
             foreach (var sample in _composer.Samples)
             {
-                var flacReader = new FlacReader(new MemoryStream(sample.Bytes));
+                var mp3FileReader = new Mp3FileReader(new MemoryStream(sample.Bytes));
 
-                _sampleDictionary[flacReader] = sample;
-                _flacPlayer.AddToPlaylist(flacReader);
+                _sampleDictionary[mp3FileReader] = sample;
+                _mp3Player.AddToPlaylist(mp3FileReader);
 
                 if (_sampleDictionary.Count == 1)
                 {
-                    _flacPlayer.Play();
+                    _mp3Player.Play();
                 }
             }
         }
 
         private void MuteVolume_CanExecute(object sender, CanExecuteRoutedEventArgs e)
         {
-            e.CanExecute = _flacPlayer != null;
+            e.CanExecute = _mp3Player != null;
         }
 
         private void MuteVolume_Executed(object sender, ExecutedRoutedEventArgs e)
         {
-            _flacPlayer.ToggleMute();
+            _mp3Player.ToggleMute();
         }
 
         private void NextTrack_Executed(object sender, ExecutedRoutedEventArgs e)
         {
-            if (_flacPlayer != null)
+            if (_mp3Player != null)
             {
-                _flacPlayer.SkipForward();
-                _flacPlayer.Play();
+                _mp3Player.SkipForward();
+                _mp3Player.Play();
 
                 PlayPauseToggleButton.IsChecked = true;
             }
@@ -372,10 +371,10 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
         private void PreviousTrack_Executed(object sender, ExecutedRoutedEventArgs e)
         {
-            if (_flacPlayer != null)
+            if (_mp3Player != null)
             {
-                _flacPlayer.SkipBack();
-                _flacPlayer.Play();
+                _mp3Player.SkipBack();
+                _mp3Player.Play();
 
                 PlayPauseToggleButton.IsChecked = true;
             }
@@ -383,13 +382,13 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
         private void ProgressSlider_DragCompleted(object sender, DragCompletedEventArgs e)
         {
-            _flacPlayer.CurrentTime = new TimeSpan((long)ProgressSlider.Value);
-            _flacPlayer.Play();
+            _mp3Player.CurrentTime = new TimeSpan((long)ProgressSlider.Value);
+            _mp3Player.Play();
         }
 
         private void ProgressSlider_DragStarted(object sender, RoutedEventArgs e)
         {
-            _flacPlayer.Stop();
+            _mp3Player.Stop();
         }
 
         private void ProgressSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
@@ -399,31 +398,31 @@ namespace NathanHarrenstein.MusicTimeline.Views
 
         private void TogglePlayPause_CanExecute(object sender, CanExecuteRoutedEventArgs e)
         {
-            e.CanExecute = _flacPlayer != null;
+            e.CanExecute = _mp3Player != null;
         }
 
         private void TogglePlayPause_Executed(object sender, ExecutedRoutedEventArgs e)
         {
-            if (_flacPlayer.PlaybackState == PlaybackState.Playing)
+            if (_mp3Player.PlaybackState == PlaybackState.Playing)
             {
-                _flacPlayer.Pause();
+                _mp3Player.Pause();
                 PlayPauseToggleButton.IsChecked = false;
             }
             else
             {
-                _flacPlayer.Play();
+                _mp3Player.Play();
                 PlayPauseToggleButton.IsChecked = true;
             }
         }
 
         private void VolumeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            if (_flacPlayer == null)
+            if (_mp3Player == null)
             {
                 return;
             }
 
-            _flacPlayer.Volume = (float)e.NewValue;
+            _mp3Player.Volume = (float)e.NewValue;
         }
     }
 }

--- a/src/MusicTimeline/packages.config
+++ b/src/MusicTimeline/packages.config
@@ -6,5 +6,4 @@
   <package id="HtmlToXamlConverter" version="1.0.5702.26891" targetFramework="net46" />
   <package id="Luminescence.Xiph" version="2.4.1.0" targetFramework="net451" />
   <package id="NAudio" version="1.7.3" targetFramework="net451" />
-  <package id="NAudio.Flac" version="1.0.5702.29018" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
While FLAC is lossless, it can be slow to load the Sample entities over an internet connection because the file sizes are relatively large. Therefore, the switch has been made to mp3 as the default codec. The FLAC files have been encoded using the standard preset (V2, ~192 vbr). Also, the tags and album art are not brought over from the FLAC files in order to further shorten loading time.
