### PR TITLE
Make composer thumbnails more efficient

### DIFF
--- a/src/MusicTimeline/Converters/ComposerToThumbnailConverter.cs
+++ b/src/MusicTimeline/Converters/ComposerToThumbnailConverter.cs
@@ -82,15 +82,15 @@ namespace NathanHarrenstein.MusicTimeline.Converters
             if (image != null)
             {
                 thumbnail = new BitmapImage();
-                thumbnail.CacheOption = BitmapCacheOption.OnLoad;
+                thumbnail.CacheOption = BitmapCacheOption.None;
                 thumbnail.BeginInit();
-                thumbnail.DecodePixelHeight = 50;
+                thumbnail.DecodePixelHeight = 40;
                 thumbnail.StreamSource = new MemoryStream(image);
                 thumbnail.EndInit();
                 thumbnail.Freeze();
 
                 var encoder = new JpegBitmapEncoder();
-                encoder.QualityLevel = 95;
+                encoder.QualityLevel = 60;
                 encoder.Frames.Add(BitmapFrame.Create(thumbnail));
 
                 using (var stream = new FileStream(thumbnailPath, FileMode.Create))


### PR DESCRIPTION
Thumbnails have been reduced in quality and height (the height of a composer event was shortened in an earlier commit, but the thumbnail heights were left unchanged). 60 was chosen for quality setting based on the information in the following article: http://www.hongkiat.com/blog/jpeg-optimization-guide/
